### PR TITLE
Routing and Context Overhaul

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User
 from django.db.models import Q
 from rest_framework import generics, permissions, request, response, status, views
 
-from .models import Video, Profile
+from .models import Video
 from .serializers import (
     ProfileSerializer,
     ReportSerializer,
@@ -27,8 +27,10 @@ class UserRegistrationView(generics.CreateAPIView):
 
         return response
 
+
 class UserAccountDeleteView(views.APIView):
     permission_classes = (permissions.AllowAny,)
+
     def delete(self, request):
         req_user = request.user
         req_user.delete()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,7 +41,6 @@ const useStyles = makeStyles({
 function MainPage() {
   return (
     <ul>
-      <LinkItem to="/login" text="Tokens" />
       <LinkItem to="/Record" text="Record" />
       <LinkItem to="/Watch" text="Watch" />
       <LinkItem to="/Profile" text="Profile" />

--- a/frontend/src/FullPageRoutes/TokenPage.tsx
+++ b/frontend/src/FullPageRoutes/TokenPage.tsx
@@ -4,15 +4,10 @@ import LoginForm, {
   ColorButton,
 } from "../components/LoginForm"
 import SignupForm from "../components/SignupForm"
-import Dashboard from "../components/Dashboard"
-import { request } from "../utils/fetch"
+import { parseIdentity, request } from "../utils/fetch"
 import { Grid, Paper } from "@material-ui/core"
 import { makeStyles } from "@material-ui/core/styles"
-
-type TokenResponse = {
-  username: string
-  token: string
-}
+import { useUser } from "../utils/context"
 
 const useStyles = makeStyles({
   paperStyle: {
@@ -30,47 +25,33 @@ const useStyles = makeStyles({
 
 export default function TokenPage(): JSX.Element {
   const [displayedForm, setDisplayedForm] = React.useState<string | null>(null)
-  const [logged_in, setLoggedIn] = React.useState<boolean>(false)
-  const [email, setEmail] = React.useState<string | null>(null)
   const [errMessage, seterrMessage] = React.useState<string | null>(null)
+  const [, setUser] = useUser()
   const classes = useStyles()
 
   React.useEffect(() => {
     seterrMessage(null)
-  }, [displayedForm, logged_in])
+  }, [displayedForm])
 
-  const handle_login = ({ e, ...data }: UserHandlerArgs) => {
-    e.preventDefault()
-    request<TokenResponse>({
+  const handle_login = ({ ...data }: UserHandlerArgs) => {
+    request({
       path: "/api/login/",
       method: "post",
       body: data,
-    }).then((json) => {
-      setLoggedIn(true)
-      setEmail(json.parsedBody.username)
-      setDisplayedForm(null)
-      seterrMessage(null)
+      parser: parseIdentity,
+    }).then(() => {
+      setUser({})
     })
   }
 
-  const handle_signup = ({ e, ...data }: UserHandlerArgs) => {
-    e.preventDefault()
-    request<TokenResponse>({
+  const handle_signup = ({ ...data }: UserHandlerArgs) => {
+    request({
       path: "/api/register/",
       method: "post",
       body: data,
-    }).then((resp) => {
-      setLoggedIn(true)
-      setDisplayedForm(null)
-      setEmail(resp.parsedBody.username)
-    })
-  }
-
-  const handle_logout = () => {
-    request({ path: "/api/logout/", method: "post" }).then(() => {
-      setLoggedIn(false)
-      setEmail(null)
-      setDisplayedForm("login")
+      parser: parseIdentity,
+    }).then(() => {
+      setUser({})
     })
   }
 
@@ -80,9 +61,7 @@ export default function TokenPage(): JSX.Element {
 
   return (
     <>
-      {logged_in === true ? (
-        <Dashboard handle_logout={handle_logout} email={email} />
-      ) : displayedForm === "signup" ? (
+      {displayedForm === "signup" ? (
         <SignupForm handle_signup={handle_signup} errorMessage={errMessage} />
       ) : (
         <Grid container className={classes.pageStyle}>

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -8,19 +8,19 @@ import {
   Checkbox,
   Button,
   Typography,
-  Link,
+  Link as MuiLink,
 } from "@material-ui/core"
 import { withStyles, makeStyles } from "@material-ui/core/styles"
 import LockOutlinedIcon from "@material-ui/icons/LockOutlined"
 import { red } from "@material-ui/core/colors"
+import { Link } from "react-router-dom"
 
 export type UserHandlerArgs = {
-  e: React.FormEvent<HTMLFormElement>
   username: string | null
   password: string | null
 }
 type LoginFormProps = {
-  handle_login: ({ e, username, password }: UserHandlerArgs) => void
+  handle_login: ({ username, password }: UserHandlerArgs) => void
   errorMessage: string | null
 }
 
@@ -36,6 +36,11 @@ export const useStyles = makeStyles({
   },
   btnstyle: {
     margin: "8px 0",
+    color: "#fff",
+    backgroundColor: red[500],
+    "&:hover": {
+      backgroundColor: red[700],
+    },
   },
 })
 
@@ -73,7 +78,7 @@ export default function LoginForm({
           </Avatar>
           <h2>Log In </h2>
         </Grid>
-        <form onSubmit={(e) => handle_login({ e, username, password })}>
+        <form>
           <TextField
             label="Email"
             placeholder="Enter email"
@@ -96,16 +101,19 @@ export default function LoginForm({
             control={<Checkbox name="checkedB" color="primary" />}
             label="Stay Signed in"
           />
-          <ColorButton
+          <Button
             type="submit"
             variant="contained"
             fullWidth
             className={classes.btnstyle}
+            component={Link}
+            to="/"
+            onClick={() => handle_login({ username, password })}
           >
             Sign In
-          </ColorButton>
+          </Button>
           <Typography>
-            <Link href="#">Forgot password</Link>
+            <MuiLink href="#">Forgot password</MuiLink>
           </Typography>
           <br />
           <span>{errorMessage}</span>

--- a/frontend/src/components/SignupForm.tsx
+++ b/frontend/src/components/SignupForm.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { UserHandlerArgs, useStyles, ColorButton } from "./LoginForm"
+import { UserHandlerArgs, useStyles } from "./LoginForm"
 import {
   Avatar,
   Paper,
@@ -7,11 +7,13 @@ import {
   TextField,
   FormControlLabel,
   Checkbox,
+  Button,
 } from "@material-ui/core"
 import AccountCircleIcon from "@material-ui/icons/AccountCircle"
+import { Link } from "react-router-dom"
 
 type SignupFormProps = {
-  handle_signup: ({ e, username, password }: UserHandlerArgs) => void
+  handle_signup: ({ username, password }: UserHandlerArgs) => void
   errorMessage: string | null
 }
 export default function SignupForm({
@@ -38,7 +40,7 @@ export default function SignupForm({
           </Avatar>
           <h2>Sign Up </h2>
         </Grid>
-        <form onSubmit={(e) => handle_signup({ e, username, password })}>
+        <form>
           <TextField
             label="Email"
             placeholder="Enter email"
@@ -61,14 +63,17 @@ export default function SignupForm({
             control={<Checkbox name="checkedB" color="primary" />}
             label="Stay Signed in"
           />
-          <ColorButton
+          <Button
             type="submit"
             variant="contained"
             fullWidth
             className={classes.btnstyle}
+            component={Link}
+            to="/"
+            onClick={() => handle_signup({ username, password })}
           >
             Sign Up
-          </ColorButton>
+          </Button>
           <br />
           <span>{errorMessage}</span>
           <br />

--- a/frontend/src/utils/context.tsx
+++ b/frontend/src/utils/context.tsx
@@ -3,21 +3,36 @@ import * as React from "react"
 export type Nullable<T> = T | null
 export type NullableId = Nullable<number>
 
+export type User = Record<string, unknown>
+
+type ContextValueType<T> = [
+  Nullable<T>,
+  React.Dispatch<React.SetStateAction<Nullable<T>>>
+]
+
 // Define the type so that createContext understands what to expect for focusedUser
 type AppContextType = {
-  focusedUser: [
-    NullableId,
-    Nullable<React.Dispatch<React.SetStateAction<NullableId>>>
-  ]
+  user: ContextValueType<User>
+  focusedUser: ContextValueType<number>
+}
+
+function createContextValueType<T>(): ContextValueType<T> {
+  return [null, () => {}] // eslint-disable-line
 }
 
 // Even though this is initialized as null, using it will supply the correct type
 export const AppContext = React.createContext<AppContextType>({
-  focusedUser: [null, null],
+  user: createContextValueType<User>(),
+  focusedUser: createContextValueType<number>(),
 })
 
 //This is gross, but we need to explicitly get just focusedUser
 export default function useFocusedUser(): AppContextType["focusedUser"] {
   const context = React.useContext(AppContext)
   return context.focusedUser
+}
+
+export function useUser(): AppContextType["user"] {
+  const context = React.useContext(AppContext)
+  return context.user
 }

--- a/frontend/src/utils/fetch.tsx
+++ b/frontend/src/utils/fetch.tsx
@@ -25,6 +25,11 @@ async function parseAsJson<T>(res: Response): Promise<T> {
   return (await res.json()) as T
 }
 
+//This is mainly used when a request does not have a response with data
+export async function parseIdentity(res: Response): Promise<Response> {
+  return await res
+}
+
 const defaultRequestArgs = {
   headers: {
     "Content-Type": "application/json",


### PR DESCRIPTION
- Added `user` to App Context
- Made everything related to App Context more DRY
- Pulled `AppContext.Provider` into separate wrapper
- Added condition to switch so that logged out users can only route to login
- Hooked up the logout button
- Removed dashboard from tokenpage
- Added routing so that login/logout/register now route to appropriate locations
- Added parseIdentity for non-responsive requests