### PR TITLE
Set venv binary directory correctly for Windows

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -11,19 +11,20 @@ if [ -z "$venvdir" -o "$venvdir" = '.' ]; then
     exit 1
 fi
 
+[ -d "$venvdir/bin" ] && bindir="bin" || bindir="Scripts"
 err=0
 
 # Check python source code style
 staged_files="$(git diff --staged --name-only --diff-filter=ACMR | egrep '\.pyi?$')"
 if [ -n "$staged_files" ]; then
     echo Running isort
-    "$venvdir/bin/isort" --profile black --check-only $staged_files
+    "$venvdir/$bindir/isort" --profile black --check-only $staged_files
     err=$((err|$?))
     echo Running black
-    "$venvdir/bin/black" --check $staged_files
+    "$venvdir/$bindir/black" --check $staged_files
     err=$((err|$?))
     echo Running flake8
-    "$venvdir/bin/flake8" $staged_files
+    "$venvdir/$bindir/flake8" $staged_files
     err=$((err|$?))
 fi
 


### PR DESCRIPTION
This is just a simple fix for the pre-commit hook. Sharelle was having issues because her virtual environment was generated with windows python utilities and had a `Scripts` directory instead of a `bin` directory.