### PR TITLE
Pause Movie Before Sending

### DIFF
--- a/frontend/src/FullPageRoutes/RecordPage.tsx
+++ b/frontend/src/FullPageRoutes/RecordPage.tsx
@@ -23,6 +23,10 @@ function sendVideo(
   history: History
 ): void {
   if (movie) {
+    movie.pause()
+    //@TODO: The progressRef for the timeline bar is still subscribed to the movie,
+    // so they both need to be paused
+    // vd.event.unsubscribe(movie, "movie.timeupdate", someListener)
     movie
       .record({
         frameRate: 60,


### PR DESCRIPTION
Still causes an error, but I think it's acceptable for now.
Before: Attempting to send a movie while it was playing would fail because the movie cannot record and play at the same time.